### PR TITLE
Updates for powerpc systems

### DIFF
--- a/runtime-cleanup.tmpl
+++ b/runtime-cleanup.tmpl
@@ -7,7 +7,7 @@ remove usr/share/i18n
 ## not required packages installed as dependencies
 ## no perl besides s390x
 ## perl needed for powerpc-utils and fbset on PPC
-%if basearch not in ("ppc", "ppc64", "ppc64le", "s390x"):
+%if basearch not in ("ppc", "s390x"):
     removepkg perl*
 %endif
 ## no sound support, thanks
@@ -255,10 +255,7 @@ removefrom ncurses /usr/bin/captoinfo /usr/bin/infocmp /usr/bin/infotocap
 removefrom ncurses /usr/bin/reset /usr/bin/tabs /usr/bin/tic /usr/bin/toe
 removefrom ncurses /usr/bin/tput /usr/bin/tset
 removefrom ncurses-libs /usr/${libdir}/libform*
-## libmenu.so is needed by lp_diag binary from ppc64-diag which is a PowerPc specific package
-%if basearch not in ("ppc", "ppc64", "ppc64le"):
-    removefrom ncurses-libs /usr/${libdir}/libmenu*
-%endif
+removefrom ncurses-libs /usr/${libdir}/libmenu*
 removefrom ncurses-libs /usr/${libdir}/libpanel.* /usr/${libdir}/libtic*
 removefrom net-tools */bin/netstat */sbin/ether-wake */sbin/ipmaddr
 removefrom net-tools */sbin/iptunnel */sbin/mii-diag */sbin/mii-tool

--- a/runtime-install.tmpl
+++ b/runtime-install.tmpl
@@ -33,7 +33,7 @@ installpkg grubby
     installpkg biosdevname memtest86+ syslinux
 %endif
 %if basearch in ("ppc", "ppc64", "ppc64le"):
-    installpkg fbset hfsutils kernel-bootwrapper ppc64-utils ppc64-diag
+    installpkg fbset hfsutils kernel-bootwrapper powerpc-utils-core
     installpkg grub2-tools grub2-tools-minimal grub2-tools-extra
     installpkg grub2-${basearch}
 %endif


### PR DESCRIPTION
Switch to powerpc-utils-core and drop ppc64-diag

Note: this is dependent upon powerpc-utils 1.3.4 being built first, which is pending in Koji.